### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/yudukikun5120/Kanji-Clustering-API/security/code-scanning/3](https://github.com/yudukikun5120/Kanji-Clustering-API/security/code-scanning/3)

Add an explicit top-level `permissions` block to `.github/workflows/code_quality.yml` so all jobs inherit least-privilege token access.  
Best fix here: set:

- `contents: read`

This is sufficient for `actions/checkout` and read-only CI tasks (ruff, mypy, pytest) and does not alter existing workflow functionality.  
Change location: directly under the `on:` trigger block (before `jobs:`), so it applies uniformly to `ruff`, `mypy`, and `pytest`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
